### PR TITLE
Add ticket resolution duration

### DIFF
--- a/app.py
+++ b/app.py
@@ -46,6 +46,12 @@ class FailureReport(db.Model):
     failure_type = db.Column(db.String(100), nullable=False)
     resolved = db.Column(db.Boolean, default=True)
 
+    @property
+    def resolution_delta(self):
+        if self.resolved and self.date_solved and self.date_reported:
+            return self.date_solved - self.date_reported
+        return None
+
 # --- Routes ---
 @app.route('/', methods=['GET', 'POST'])
 def index():

--- a/templates/gctd.html
+++ b/templates/gctd.html
@@ -22,6 +22,7 @@
         <th>Failure Mode</th>
         <th>Root Cause</th>
         <th>Failure Type</th>
+        <th>Resolution Time</th>
       </tr>
     </thead>
     <tbody>
@@ -34,6 +35,7 @@
         <td>{{ ticket.failure_mode }}</td>
         <td>{{ ticket.root_cause }}</td>
         <td>{{ ticket.failure_type }}</td>
+        <td>{% if ticket.resolution_delta %}{{ ticket.resolution_delta }}{% else %}-{% endif %}</td>
       </tr>
       {% endfor %}
     </tbody>


### PR DESCRIPTION
## Summary
- expose the time between report and resolution in FailureReport
- display resolution time in the GCTD ticket list

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684be6dadec883289ec38a814f14ffa6