### PR TITLE
Add bucket to failure reports

### DIFF
--- a/app.py
+++ b/app.py
@@ -44,6 +44,7 @@ class FailureReport(db.Model):
     failure_mode = db.Column(db.String(200), nullable=False)
     root_cause = db.Column(db.String(200), nullable=False)
     failure_type = db.Column(db.String(100), nullable=False)
+    bucket = db.Column(db.String(50))
     resolved = db.Column(db.Boolean, default=True)
 
 # --- Routes ---
@@ -59,7 +60,8 @@ def index():
             asset=form_data['asset'],
             failure_mode=form_data['failure_mode'],
             root_cause=form_data['root_cause'],
-            failure_type=form_data['failure_type']
+            failure_type=form_data['failure_type'],
+            bucket=form_data['bucket']
         )
         db.session.add(report)
         db.session.commit()

--- a/templates/gctd.html
+++ b/templates/gctd.html
@@ -22,6 +22,7 @@
         <th>Failure Mode</th>
         <th>Root Cause</th>
         <th>Failure Type</th>
+        <th>Bucket</th>
       </tr>
     </thead>
     <tbody>
@@ -34,6 +35,7 @@
         <td>{{ ticket.failure_mode }}</td>
         <td>{{ ticket.root_cause }}</td>
         <td>{{ ticket.failure_type }}</td>
+        <td>{{ ticket.bucket }}</td>
       </tr>
       {% endfor %}
     </tbody>

--- a/templates/index.html
+++ b/templates/index.html
@@ -55,6 +55,14 @@
     <label for="failure_type">Failure Type</label>
     <input type="text" name="failure_type" id="failure_type" required>
 
+    <label for="bucket">Bucket</label>
+    <select name="bucket" id="bucket" required>
+      <option value="Safety">Safety</option>
+      <option value="Quality">Quality</option>
+      <option value="Delivery">Delivery</option>
+      <option value="Cost">Cost</option>
+    </select>
+
     <button type="submit">Submit Report</button>
   </form>
 </body>


### PR DESCRIPTION
## Summary
- extend `FailureReport` model with a `bucket` column
- collect bucket in the report form
- display bucket in the GCTD view

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684be6d85d7c832895a81cce4f81dd6b