### PR TITLE
Add ticket resolution support

### DIFF
--- a/app.py
+++ b/app.py
@@ -85,6 +85,15 @@ def gctd_view():
     tickets = FailureReport.query.order_by(FailureReport.date_reported.desc()).all()
     return render_template('gctd.html', tickets=tickets)
 
+# --- Resolve Ticket Route ---
+@app.route('/resolve/<int:id>')
+def resolve_ticket(id):
+    ticket = FailureReport.query.get_or_404(id)
+    ticket.resolved = True
+    ticket.date_solved = datetime.utcnow()
+    db.session.commit()
+    return redirect('/gctd')
+
 # --- Main ---
 if __name__ == '__main__':
     with app.app_context():

--- a/templates/gctd.html
+++ b/templates/gctd.html
@@ -22,6 +22,7 @@
         <th>Failure Mode</th>
         <th>Root Cause</th>
         <th>Failure Type</th>
+        <th>Actions</th>
       </tr>
     </thead>
     <tbody>
@@ -34,6 +35,13 @@
         <td>{{ ticket.failure_mode }}</td>
         <td>{{ ticket.root_cause }}</td>
         <td>{{ ticket.failure_type }}</td>
+        <td>
+          {% if ticket.resolved %}
+            Resolved
+          {% else %}
+            <a href="{{ url_for('resolve_ticket', id=ticket.id) }}">Resolve</a>
+          {% endif %}
+        </td>
       </tr>
       {% endfor %}
     </tbody>


### PR DESCRIPTION
## Summary
- add `/resolve/<id>` endpoint to resolve a ticket
- display a Resolve link in GCTD view

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684be6d6a168832885bf93db81a2d835