### PR TITLE
Add /logout route with template links

### DIFF
--- a/app.py
+++ b/app.py
@@ -85,6 +85,16 @@ def gctd_view():
     tickets = FailureReport.query.order_by(FailureReport.date_reported.desc()).all()
     return render_template('gctd.html', tickets=tickets)
 
+
+# --- Logout ---
+@app.route('/logout')
+def logout():
+    """Trigger browser re-authentication by returning a 401."""
+    return Response(
+        'Logged out', 401,
+        {'WWW-Authenticate': 'Basic realm="Login Required"'}
+    )
+
 # --- Main ---
 if __name__ == '__main__':
     with app.app_context():

--- a/templates/gctd.html
+++ b/templates/gctd.html
@@ -10,10 +10,11 @@
     th {background-color: #f2f2f2;}
   </style>
 </head>
-<body>
-  <h1>Submitted Tickets</h1>
-  <table>
-    <thead>
+  <body>
+    <h1>Submitted Tickets</h1>
+    <p><a href="/logout">Logout</a></p>
+    <table>
+      <thead>
       <tr>
         <th>ID</th>
         <th>Date</th>

--- a/templates/index.html
+++ b/templates/index.html
@@ -37,9 +37,10 @@
     }
   </style>
 </head>
-<body>
-  <h1>Failure Entry Form</h1>
-  <form method="POST">
+  <body>
+    <h1>Failure Entry Form</h1>
+    <p><a href="/logout">Logout</a></p>
+    <form method="POST">
     <label for="location">Location</label>
     <input type="text" name="location" id="location" required>
 


### PR DESCRIPTION
## Summary
- add Flask route `/logout` returning a 401 to re-prompt credentials
- link to `/logout` from both templates

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684be6d2c4088328a7e8dfe67d6a20d1